### PR TITLE
Fix header alignment: Theme/Scale labels and dropdowns vertical alignment

### DIFF
--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -146,6 +146,10 @@ body {
   font-size: 12px;
   color: var(--storybook-text-muted);
   font-weight: 600;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  height: 24px;
 }
 
 .control-select {
@@ -157,6 +161,10 @@ body {
   color: var(--storybook-text);
   cursor: pointer;
   transition: border-color 0.2s ease;
+  height: 24px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
 }
 
 .control-select:hover {


### PR DESCRIPTION
## Problem
The "Theme" and "Scale" labels in the header were not properly vertically aligned with their respective dropdown controls (Light/Dark and Medium/Large), creating a visual inconsistency.

## Solution
- Set consistent height (24px) for both labels and select dropdowns
- Added `line-height: 1` to prevent text baseline alignment issues
- Used flexbox properties (`display: flex`, `align-items: center`) for precise vertical centering
- Ensures consistent visual alignment across all header controls

## Testing
- [x] Verified alignment in both light and dark themes
- [x] Tested with both medium and large scale settings
- [x] Confirmed no regression in other header elements

## Screenshots
Before: Labels appeared slightly offset from dropdown controls
After: Perfect vertical alignment between labels and dropdowns

This change improves the overall polish and professional appearance of the application header.