### PR TITLE
title-update

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,600;0,700;0,900;1,400;1,700&display=swap" rel="stylesheet">
     
-    <title>Adobe Spectrum Components</title>
+    <title>Adobe Spectrum Design System</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
Updated the page title from "Adobe Spectrum Components" to "Adobe Spectrum Design System" for better branding alignment.