### PR TITLE
Fix homepage scrolling issue

### DIFF
--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -7,7 +7,7 @@
 
 html, body {
   height: 100%;
-  overflow: hidden;
+  overflow: auto;
 }
 
 body {
@@ -298,7 +298,7 @@ body {
 .main-content {
   flex: 1;
   background-color: var(--storybook-bg);
-  overflow: hidden;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
 }
@@ -308,7 +308,7 @@ body {
   height: 100%;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 .component-header {
@@ -441,6 +441,7 @@ body {
 .home-content {
   padding: 40px 30px;
   max-width: 800px;
+  overflow-y: auto;
 }
 
 .home-section {


### PR DESCRIPTION
The homepage scrolling issue was addressed by modifying `src/styles/App.css`.

The problem stemmed from multiple parent containers having `overflow: hidden`, which prevented content from scrolling.

Changes were made to allow content to scroll when it overflows:
*   `html, body` was updated from `overflow: hidden` to `overflow: auto`.
*   `.main-content` was changed from `overflow: hidden` to `overflow-y: auto`.
*   `.component-view` was changed from `overflow: hidden` to `overflow-y: auto`.
*   `overflow-y: auto` was added to `.home-content`.

These adjustments ensure that the homepage content is no longer cut off and can be fully scrolled, improving accessibility for all sections.