### PR TITLE
Fix homepage scrolling issue (AD-12)

### DIFF
--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -298,17 +298,17 @@ body {
 .main-content {
   flex: 1;
   background-color: var(--storybook-bg);
-  overflow: hidden;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
 }
 
 /* Component View */
 .component-view {
-  height: 100%;
+  flex: 1;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 .component-header {


### PR DESCRIPTION
## Summary
Fixes the homepage scrolling issue reported in Jira ticket AD-12.

## Problem
The homepage content was not scrollable due to `overflow: hidden` CSS properties on both the main content area and component view containers. This prevented users from accessing content that extended beyond the viewport height.

## Solution
- Changed `main-content` overflow from `hidden` to `overflow-y: auto` to enable vertical scrolling
- Updated `component-view` to use `flex: 1` and `overflow-y: auto` for proper scrolling behavior
- Ensures homepage content can be scrolled when it exceeds viewport height

## Testing
- [x] Verified the homepage now scrolls properly
- [x] Confirmed layout remains intact
- [x] Tested on development server (localhost:3000)

## Related Issues
- Closes AD-12: Homepage doesn't scroll